### PR TITLE
feat: :sparkles: allow TLS certificates for authentication (support AWS IoT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Parameters:
 | -U / --username | MQTT Username |
 | -P / --password | MQTT Password |
 | -i / --id | MQTT Client ID |
+| -C / --cert | TLS Certificate |
+| -K / --key | TLS Key |
+| -S / --cacert | TLS CA Certificate |
 | Last argument | ASGI Apllication |
 
 ## Consumer

--- a/mqttasgi/cli.py
+++ b/mqttasgi/cli.py
@@ -18,6 +18,10 @@ def main():
     parser.add_argument("-U", "--username", help="MQTT username to authorised connection")
     parser.add_argument("-P", "--password", help="MQTT password to authorised connection")
     parser.add_argument("-i", "--id", dest="client_id", help="MQTT Client ID")
+    # add support for certificate authentication (TLS)
+    parser.add_argument("-C", "--cert", help="MQTT TLS certificate", default=None)
+    parser.add_argument("-K", "--key", help="MQTT TLS key", default=None)
+    parser.add_argument("-S", "--cacert", help="MQTT TLS CA certificate", default=None)
 
     parser.add_argument("application",
                         help=("The ASGI application instance to use as "
@@ -43,7 +47,10 @@ def main():
         args.password,
         args.client_id,
         logger=logger,
-        clean_session=args.cleansession
+        clean_session=args.cleansession,
+        cert=args.cert,
+        key=args.key,
+        ca_cert=args.cacert,
     )
 
     server.run()

--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 class Server(object):
     def __init__(self, application, host, port, username=None, password=None,
                  client_id=2407, mqtt_type_pub=None, mqtt_type_usub=None, mqtt_type_sub=None,
-                 mqtt_type_msg=None, connect_max_retries=3, logger=None, clean_session=True):
+                 mqtt_type_msg=None, connect_max_retries=3, logger=None, clean_session=True, cert=None, key=None, ca_cert=None):
 
         self.application_type = application
         self.application_data = {}
@@ -40,6 +40,10 @@ class Server(object):
         # self.client.enable_logger(self.log)
         self.username = username
         self.password = password
+        # certificates
+        self.cert = cert
+        self.key = key
+        self.ca_cert = ca_cert
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self._on_disconnect
         self.connect_max_retries = connect_max_retries
@@ -142,6 +146,14 @@ class Server(object):
 
         if self.username:
             self.client.username_pw_set(username=self.username, password=self.password)
+            
+        if all([self.cert, self.key, self.ca_cert]):
+            self.client.tls_set(
+                ca_certs=self.ca_cert,
+                certfile=self.cert,
+                keyfile=self.key,
+            )
+
 
         self.client.connect(self.host, self.port)
 


### PR DESCRIPTION
Hi, 

In this PR I've added the ability to provide a path to the certificate files that the client will use to authenticate. This allows authentication with AWS IoT Core using certificates only, which is a requirement of mine.

I've tested this as working to authenticate with AWS, without a username or password.