### PR TITLE
set default configuration from environment

### DIFF
--- a/mqttasgi/cli.py
+++ b/mqttasgi/cli.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 from .server import Server
 from .utils import get_application
 
@@ -8,20 +9,26 @@ logger = logging.getLogger(__name__)
 def main():
     parser = argparse.ArgumentParser(description="MQTT ASGI Protocol Server")
     parser.add_argument("-H", "--host", help="MQTT broker host",
-                        default="localhost")
+                        default=os.environ.get("MQTT_HOSTNAME", "localhost"))
     parser.add_argument("-p", "--port", help="MQTT broker port", type=int,
-                        default=1883)
+                        default=int(os.environ.get("MQTT_PORT", 1883)))
     parser.add_argument("-c", "--cleansession", help="MQTT Clean Session", type=bool,
-                        default=True)
-    parser.add_argument("-v", "--verbosity", type=int, default=0,
-                        help="Set verbosity")
-    parser.add_argument("-U", "--username", help="MQTT username to authorised connection")
-    parser.add_argument("-P", "--password", help="MQTT password to authorised connection")
-    parser.add_argument("-i", "--id", dest="client_id", help="MQTT Client ID")
+                        default=os.environ.get("MQTT_CLEAN", "True").lower() == "true")
+    parser.add_argument("-v", "--verbosity", type=int, help="Set verbosity",
+                        default=int(os.environ.get("VERBOSITY", 0)))
+    parser.add_argument("-U", "--username", help="MQTT username to authorised connection",
+                        default=os.environ.get("MQTT_USERNAME", None))
+    parser.add_argument("-P", "--password", help="MQTT password to authorised connection",
+                        default=os.environ.get("MQTT_PASSWORD", None))
+    parser.add_argument("-i", "--id", dest="client_id", help="MQTT Client ID",
+                        default=os.environ.get("MQTT_CLIENT_ID", None))
     # add support for certificate authentication (TLS)
-    parser.add_argument("-C", "--cert", help="MQTT TLS certificate", default=None)
-    parser.add_argument("-K", "--key", help="MQTT TLS key", default=None)
-    parser.add_argument("-S", "--cacert", help="MQTT TLS CA certificate", default=None)
+    parser.add_argument("-C", "--cert", help="MQTT TLS certificate",
+                        default=os.environ.get("TLS_CERT", None))
+    parser.add_argument("-K", "--key", help="MQTT TLS key",
+                        default=os.environ.get("TLS_KEY", None))
+    parser.add_argument("-S", "--cacert", help="MQTT TLS CA certificate",
+                        default=os.environ.get("TLS_CA", None))
 
     parser.add_argument("application",
                         help=("The ASGI application instance to use as "


### PR DESCRIPTION
Hi,

Thanks for this project !

I'm using it in a server deployed with Docker Compose, and it would be really nice to allow configuration look like:
```yml
services:
  mqttasgi:
    build: .
    env_file:
      - .env
    command: mqttasgi my_django_project.asgi:application
```

instead of:
```yml
services:
  mqttasgi:
    build: .
    command: mqttasgi -H my-hostname -U my-user -P my-secret-password my_django_project.asgi:application
```

This would allow me to avoid putting my secret password in git history :)

A similar issue exist when adding systemd service configuration for the project, and letting the end-user set the password in the Environment section of overrides.

Here is a suggestion to update defaults from the environment. Command line arguments would still take precedence over those.