### PR TITLE
Fix/mqtt broker reconnection

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Parameters:
 | -C / --cert | TLS Certificate | TLS_CERT |
 | -K / --key | TLS Key | TLS_KEY |
 | -S / --cacert | TLS CA Certificate | TLS_CA |
+| -r / --retries | Num. retries on disconnect | MQTT_RETRIES |
 | Last argument | ASGI Apllication |  |
 
 Environment variables are supported and can be set using a `.env` file on the root of the project, but passing a parameter overrides this value.

--- a/mqttasgi/cli.py
+++ b/mqttasgi/cli.py
@@ -32,6 +32,8 @@ def main():
                         default=os.environ.get("TLS_KEY", None))
     parser.add_argument("-S", "--cacert", help="MQTT TLS CA certificate",
                         default=os.environ.get("TLS_CA", None))
+    parser.add_argument("-r", "--retries", help="Maximum number of connection retries after unexpected disconnect (0 to always try to reconnect)",
+                        default=os.environ.get("MQTT_RETRIES", 3), type=int)
 
     parser.add_argument("application",
                         help=("The ASGI application instance to use as "
@@ -61,6 +63,7 @@ def main():
         cert=args.cert,
         key=args.key,
         ca_cert=args.cacert,
+        connect_max_retries=args.retries
     )
 
     server.run()

--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -74,42 +74,46 @@ class Server(object):
                 self.log.exception(e)
 
     def _on_disconnect(self, client, userdata, rc):
-        self.log.warning("[mqttasgi][connection][disconnected] - Disconnected from {}:{}".format(self.host,self.port))
+        self.log.warning("[mqttasgi][connection][disconnected] - Disconnected from {}:{}".format(self.host, self.port))
         if not self.stop:
             if self.connect_max_retries != 0:
-                for i in range(self.connect_max_retries):
-                    self.log.info("[mqttasgi][connection][reconnect] - Attempting {} reconnect".format(i+1))
+                for i in range(1, self.connect_max_retries):
+                    self.log.info("[mqttasgi][connection][reconnect] - Attempting {} reconnect".format(i))
                     try:
                         client.reconnect()
-                        self.log.warning("[mqttasgi][connection][reconnect] - Reconnected after {} attempts".format(i+1))
+                        self.log.warning("[mqttasgi][connection][reconnect] - Reconnected after {} attempts".format(i))
                         break
                     except Exception as e:
-                        if i < self.connect_max_retries:
-                            self.log.info("[mqttasgi][connection][reconnect] - Failed {} sleeping for {} seconds".format(i+1, i+1))
-                            time.sleep(i+1)
-                            continue
-                        else:
-                            for app_id in self.application_data:
-
-                                self.application_data[app_id]['receive'].put_nowait({
-                                    'type': 'mqtt.disconnect',
-                                    'mqtt': {
-
-                                    }
-                                })
-                            raise
+                        self.log.debug("[mqttasgi][connection][reconnect] - Exception occurred during reconnect", exc_info=True)
+                        time.sleep(i)
+                else:  # executed only if the for-loop completes without a break
+                    self._handle_reconnect_failure()
             else:
-                exit = False
-                tries = 0
-                while not exit:
-                    try:
-                        client.reconnect()
-                        self.log.warning("[mqttasgi][connection][reconnect] - Reconnected after {} attempts".format(tries+1))
-                        exit = True
-                        break
-                    except Exception as e:
-                        tries += 1
-                        time.sleep(tries + 1 if tries<10 else 10)
+                self._try_reconnect_infinitely(client)
+
+    def _handle_reconnect_failure(self):
+        for app_id in self.application_data:
+            self.application_data[app_id]['receive'].put_nowait({
+                'type': 'mqtt.disconnect',
+                'mqtt': {}
+            })
+        raise Exception("[mqttasgi][connection][reconnect] - Failed to reconnect after {} attempts".format(self.connect_max_retries))
+
+    def _try_reconnect_infinitely(self, client):
+        tries = 0
+        while True:
+            try:
+                time.sleep(min(tries, 10))
+                tries += 1
+                client.reconnect()
+                self.log.warning("[mqttasgi][connection][reconnect] - Reconnected after {} attempts".format(tries))
+                break
+            except KeyboardInterrupt as e:
+                self.log.warning("[mqttasgi][connection][reconnect] - Keyboard Interrupt. Stopped trying to reconnect.")
+                raise e
+            except Exception as e:
+                self.log.debug("[mqttasgi][connection][reconnect] - Exception occurred during reconnect", exc_info=True)
+
 
     def _mqtt_receive(self, subscription, topic, payload, qos):
         if subscription == -1:

--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -108,12 +108,8 @@ class Server(object):
                 client.reconnect()
                 self.log.warning("[mqttasgi][connection][reconnect] - Reconnected after {} attempts".format(tries))
                 break
-            except KeyboardInterrupt as e:
-                self.log.warning("[mqttasgi][connection][reconnect] - Keyboard Interrupt. Stopped trying to reconnect.")
-                raise e
             except Exception as e:
                 self.log.debug("[mqttasgi][connection][reconnect] - Exception occurred during reconnect", exc_info=True)
-
 
     def _mqtt_receive(self, subscription, topic, payload, qos):
         if subscription == -1:
@@ -163,8 +159,8 @@ class Server(object):
 
         self.log.info(f"MQTT loop start")
 
+        self.client.loop_start()
         while True:
-            self.client.loop(0.01)
             await asyncio.sleep(0.01)
 
     async def mqtt_publish(self, app_id, msg):


### PR DESCRIPTION
Hi @sivulich,

This is a small change to allow the application to allow re-connections to an MQTT broker if the connection is closed from the broker side. It adds a CLI flag/envvar controlling the number of retries, with `0` specifying that the application always try to reconnect. I left the default at 3, unchanged from the previous hard-coded default.

The motivation for this change was because AWS IoT Core likes to disconnect clients for "maintenance" reasons, and in a server situation we would prefer the ability to specify an "always try to reconnect" mode.

The change from using `self.client.loop(0.01)` to `self.client.loop_start()` is to allow the client loop to run in a separate thread so shutdown events can still be handled properly alongside client re-connections.