### PR TITLE
Add support for use ssl (without certificate authentication) and transport type

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Parameters:
 | -K / --key | TLS Key | TLS_KEY |  |
 | -S / --cacert | TLS CA Certificate | TLS_CA |  |
 | -SSL / --use-ssl | Use ssl (without certificate authentication) | MQTT_USE_SSL | False |
+| -T / --transport | Transport type (tcp or websockets) | MQTT_TRANSPORT | tcp |
 | -r / --retries | Num. retries on disconnect | MQTT_RETRIES | 3 |
 | Last argument | ASGI Apllication |  | |
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Parameters:
 | -C / --cert | TLS Certificate | TLS_CERT |  |
 | -K / --key | TLS Key | TLS_KEY |  |
 | -S / --cacert | TLS CA Certificate | TLS_CA |  |
+| -SSL / --use-ssl | Use ssl (without certificate authentication) | MQTT_USE_SSL | False |
 | -r / --retries | Num. retries on disconnect | MQTT_RETRIES | 3 |
 | Last argument | ASGI Apllication |  | |
 

--- a/mqttasgi/cli.py
+++ b/mqttasgi/cli.py
@@ -9,14 +9,22 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+def bool_type_converter(arg):
+    if arg.lower() == "true":
+        return True
+    elif arg.lower() == "false":
+        return False
+    raise ValueError()
+
+
 def main():
     parser = argparse.ArgumentParser(description="MQTT ASGI Protocol Server")
     parser.add_argument("-H", "--host", help="MQTT broker host",
                         default=os.environ.get("MQTT_HOSTNAME", "localhost"))
     parser.add_argument("-p", "--port", help="MQTT broker port", type=int,
                         default=int(os.environ.get("MQTT_PORT", 1883)))
-    parser.add_argument("-c", "--cleansession", help="MQTT Clean Session", type=bool,
-                        default=os.environ.get("MQTT_CLEAN", "True").lower() == "true")
+    parser.add_argument("-c", "--cleansession", help="MQTT Clean Session", type=bool_type_converter,
+                        default=bool_type_converter(os.environ.get("MQTT_CLEAN", "True")))
     parser.add_argument("-v", "--verbosity", type=int, help="Set verbosity",
                         default=int(os.environ.get("VERBOSITY", 0)))
     parser.add_argument("-U", "--username", help="MQTT username to authorised connection",
@@ -32,6 +40,8 @@ def main():
                         default=os.environ.get("TLS_KEY", None))
     parser.add_argument("-S", "--cacert", help="MQTT TLS CA certificate",
                         default=os.environ.get("TLS_CA", None))
+    parser.add_argument("-SSL", "--use-ssl", dest="use_ssl", help="Use ssl with server signed certificate",
+                        type=bool_type_converter, default=bool_type_converter(os.environ.get("MQTT_USE_SSL", "False")))
     parser.add_argument("-r", "--retries", help="Maximum number of connection retries after unexpected disconnect (0 to always try to reconnect)",
                         default=os.environ.get("MQTT_RETRIES", 3), type=int)
 
@@ -63,7 +73,8 @@ def main():
         cert=args.cert,
         key=args.key,
         ca_cert=args.cacert,
-        connect_max_retries=args.retries
+        connect_max_retries=args.retries,
+        use_ssl=args.use_ssl,
     )
 
     server.run()

--- a/mqttasgi/cli.py
+++ b/mqttasgi/cli.py
@@ -42,6 +42,8 @@ def main():
                         default=os.environ.get("TLS_CA", None))
     parser.add_argument("-SSL", "--use-ssl", dest="use_ssl", help="Use ssl with server signed certificate",
                         type=bool_type_converter, default=bool_type_converter(os.environ.get("MQTT_USE_SSL", "False")))
+    parser.add_argument("-T", "--transport", help="Transport type (tcp or websockets)",
+                        default=os.environ.get("MQTT_TRANSPORT", "tcp"))
     parser.add_argument("-r", "--retries", help="Maximum number of connection retries after unexpected disconnect (0 to always try to reconnect)",
                         default=os.environ.get("MQTT_RETRIES", 3), type=int)
 
@@ -75,6 +77,7 @@ def main():
         ca_cert=args.cacert,
         connect_max_retries=args.retries,
         use_ssl=args.use_ssl,
+        transport = args.transport
     )
 
     server.run()

--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -16,7 +16,7 @@ class Server(object):
     def __init__(self, application, host, port, username=None, password=None,
                  client_id=2407, mqtt_type_pub=None, mqtt_type_usub=None, mqtt_type_sub=None,
                  mqtt_type_msg=None, connect_max_retries=3, logger=None, clean_session=True, cert=None, key=None, ca_cert=None,
-                 use_ssl=False):
+                 use_ssl=False, transport ="tcp"):
 
         self.application_type = application
         self.application_data = {}
@@ -33,7 +33,8 @@ class Server(object):
         self.host = host
         self.port = port
         self.client_id = client_id
-        self.client = mqtt.Client(client_id=self.client_id, userdata={
+        self.transport = transport
+        self.client = mqtt.Client(client_id=self.client_id, transport=self.transport, userdata={
             "server": self,
             "host": self.host,
             "port": self.port,

--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -15,7 +15,8 @@ _logger = logging.getLogger(__name__)
 class Server(object):
     def __init__(self, application, host, port, username=None, password=None,
                  client_id=2407, mqtt_type_pub=None, mqtt_type_usub=None, mqtt_type_sub=None,
-                 mqtt_type_msg=None, connect_max_retries=3, logger=None, clean_session=True, cert=None, key=None, ca_cert=None):
+                 mqtt_type_msg=None, connect_max_retries=3, logger=None, clean_session=True, cert=None, key=None, ca_cert=None,
+                 use_ssl=False):
 
         self.application_type = application
         self.application_data = {}
@@ -45,6 +46,7 @@ class Server(object):
         self.cert = cert
         self.key = key
         self.ca_cert = ca_cert
+        self.use_ssl = use_ssl
         self.client.on_connect = self._on_connect
         self.client.on_disconnect = self._on_disconnect
         self.connect_max_retries = connect_max_retries
@@ -149,7 +151,8 @@ class Server(object):
                 certfile=self.cert,
                 keyfile=self.key,
             )
-
+        elif self.use_ssl:
+            self.client.tls_set()
         try:
             self.client.connect(self.host, self.port)
         except Exception as e:


### PR DESCRIPTION
Add the option to use ssl with CA signed server certificate and support to set the transport type, both are paho mqtt client options that are missing in this package and are required for my current project but i think they can be useful to extend the package functionality