### PR TITLE
Fix: support Python  3.14 event loop initialization

### DIFF
--- a/mqttasgi/server.py
+++ b/mqttasgi/server.py
@@ -356,9 +356,16 @@ class Server(object):
         self.application_data[app_id]['instance'] = application(scope,
                                                                 receive=self.application_data[app_id]['receive'].get,
                                                                 send=lambda message: self._application_send(app_id, message))
+        # ---- Python 3.14-safe event-loop init ----
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        # -----------------------------------------
         task = asyncio.ensure_future(
             self.application_data[app_id]['instance'],
-            loop=asyncio.get_event_loop()
+            loop=loop
         )
         self.application_data[app_id]['task'] = task
         self.application_data[app_id]['subscriptions'] = {}


### PR DESCRIPTION
## Summary
Fixes `RuntimeError: There is no current event loop in thread 'MainThread'`
when running under Python 3.14.

## Details
- Replaced `asyncio.get_event_loop()` with
  `asyncio.get_running_loop()` and fallback creation.
- Keeps backward compatibility with older Pythons (3.8+).

